### PR TITLE
Added bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+    "name": "deb.js",
+    "description": "Minimalistic JavaScript library for debugging in the browser.",
+    "version": "0.0.1",
+    "license": "MIT",
+    "_source": "git://github.com/krasimir/deb.js.git",
+    "homepage": "https://github.com/krasimir/deb.js",
+    "main": "build/deb.min.js",
+    "keywords": [
+        "javascript",
+        "js",
+        "lib",
+        "debug",
+        "browser",
+        "debugger"
+    ],
+    "ignore": [
+        "/.*",
+        "chrome",
+        "example"
+    ]
+}


### PR DESCRIPTION
Added bower.json for bower support, after merge a [semver](http://semver.org/) tag (v0.0.1) needs to be added, so that bower can properly register the package.
After that this command needs to be ran:

```
bower register deb.js git://github.com/krasimir/deb.js.git
```

I guess since you're the author you should have the honor :wink: 
(If again you don't want to bother, I'll do it)
