### PR TITLE
Null checking new Error().stack;

### DIFF
--- a/lib/deb.js
+++ b/lib/deb.js
@@ -68,7 +68,7 @@
 		return function() {
 			bg = getColor();
 			var time = Date.now();
-			fnIn((new Error()).stack.split(new RegExp("\\n")), arguments, fn);
+			fnIn(('stack' in new Error()) ? (new Error()).stack : new Error().toString().split(new RegExp("\\n")), arguments, fn);
 			var res = fn.apply(this, Array.prototype.slice.call(arguments, 0));
 			fnOut(time, res);
 			return res;


### PR DESCRIPTION
In Safari and/or iOS Safari, (new Error().stack) throws an undefined exception. Using new Error().toString() as a backup.
