### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
     "name": "deb.js",
     "description": "Minimalistic JavaScript library for debugging in the browser.",
-    "version": "0.0.2",
     "license": "MIT",
     "_source": "git://github.com/krasimir/deb.js.git",
     "homepage": "https://github.com/krasimir/deb.js",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property